### PR TITLE
Bugfix/tesb/karaf 4.2.10.x/tesb 31632

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* xldai@talend.com amattes@talend.com jgreffe@talend.com

--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: ':karaf-maven-plugin,org.apache.karaf.features:framework,org.apache.karaf.features:static'
+        MVN_MODULES: ':karaf-maven-plugin,org.apache.karaf.features:standard,org.apache.karaf.features:framework,org.apache.karaf.features:static,:org.apache.karaf.shell.ssh'
 )

--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -33,8 +33,10 @@
     <packaging>pom</packaging>
     <name>Apache Karaf :: Assemblies :: Features :: Standard</name>
     <description>Standard providing core Karaf features</description>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${standard.features.tesb.version}</revision>
         <appendedResourcesDirectory>${basedir}/../../../../etc/appended-resources</appendedResourcesDirectory>
         <javax.annotation.version>1.3</javax.annotation.version>
         <geronimo.jaspic-spec.version>1.1</geronimo.jaspic-spec.version>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1025,8 +1025,7 @@ role=${env:ORG_APACHE_KARAF_WEBCONSOLE_ROLE:-admin}
         <bundle start-level="30">mvn:org.apache.sshd/sshd-sftp/${sshd.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.not-yet-commons-ssl/0.3.11_1</bundle>
         <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.66</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/1.66</bundle>
-        <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${upstream.version}</bundle>
+        <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${org.apache.karaf.shell.ssh.tesb.version}</bundle>
     </feature>
 
     <feature name="management" description="Provide a JMX MBeanServer and a set of MBeans in Karaf" version="${upstream.version}">

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1024,7 +1024,7 @@ role=${env:ORG_APACHE_KARAF_WEBCONSOLE_ROLE:-admin}
         <bundle start-level="30">mvn:org.apache.sshd/sshd-scp/${sshd.version}</bundle>
         <bundle start-level="30">mvn:org.apache.sshd/sshd-sftp/${sshd.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.not-yet-commons-ssl/0.3.11_1</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.66</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/1.68</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${org.apache.karaf.shell.ssh.tesb.version}</bundle>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -138,10 +138,12 @@
 
     <properties>
         <upstream.version>4.2.10</upstream.version>
+        <standard.features.tesb.version>4.2.10.tesb1</standard.features.tesb.version>
         <framework.features.tesb.version>4.2.10.tesb1</framework.features.tesb.version>
         <static.features.tesb.version>4.2.10.tesb1</static.features.tesb.version>
         <karaf-maven-plugin.tesb.version>4.2.10.tesb1</karaf-maven-plugin.tesb.version>
         <pax-logging-log4j2.tesb.version>1.11.7.tesb1</pax-logging-log4j2.tesb.version>
+        <org.apache.karaf.shell.ssh.tesb.version>4.2.10.tesb1</org.apache.karaf.shell.ssh.tesb.version>
         <activemq.version>5.15.11</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
         <aspectj.bundle.version>1.9.5_1</aspectj.bundle.version>
@@ -616,7 +618,7 @@
             <dependency>
                 <groupId>org.apache.karaf.shell</groupId>
                 <artifactId>org.apache.karaf.shell.ssh</artifactId>
-                <version>${upstream.version}</version>
+                <version>${org.apache.karaf.shell.ssh.tesb.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf.shell</groupId>
@@ -1854,10 +1856,12 @@
                             <!-- something like :
                             <my.custom.property>${my.custom.property}</my.custom.property>
                             -->
+                            <standard.features.tesb.version>${standard.features.tesb.version}</standard.features.tesb.version>
                             <framework.features.tesb.version>${framework.features.tesb.version}</framework.features.tesb.version>
                             <static.features.tesb.version>${static.features.tesb.version}</static.features.tesb.version>
                             <pax-logging-log4j2.tesb.version>${pax-logging-log4j2.tesb.version}</pax-logging-log4j2.tesb.version>
                             <karaf-maven-plugin.tesb.version>${karaf-maven-plugin.tesb.version}</karaf-maven-plugin.tesb.version>
+                            <org.apache.karaf.shell.ssh.tesb.version>${org.apache.karaf.shell.ssh.tesb.version}</org.apache.karaf.shell.ssh.tesb.version>
                         </properties>
                     </configuration>
                     <executions>

--- a/shell/ssh/pom.xml
+++ b/shell/ssh/pom.xml
@@ -32,8 +32,10 @@
     <packaging>bundle</packaging>
     <name>Apache Karaf :: Shell :: SSH</name>
     <description>This bundle provides SSH support to the Karaf console.</description>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${org.apache.karaf.shell.ssh.tesb.version}</revision>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
     </properties>
 

--- a/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
+++ b/shell/ssh/src/main/java/org/apache/karaf/shell/ssh/ShellCommand.java
@@ -143,8 +143,8 @@ public class ShellCommand implements Command {
             exitStatus = 1;
             LOGGER.error("Unable to start shell", e);
         } finally {
-            StreamUtils.close(in, out, err);
             callback.onExit(exitStatus);
+            StreamUtils.close(in, out, err);
         }
     }
 


### PR DESCRIPTION
2 fixes:
TESB-31632: ssh auto-exit
TESB-31663: Bouncycastle update to 1.68 due to CVE.