### PR TITLE
fix(TPRUN-6290) bcprov-jdk15on:1.69 | CVE-2023-33201

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1029,9 +1029,9 @@ role=${env:ORG_APACHE_KARAF_WEBCONSOLE_ROLE:-admin}
         <bundle start-level="30">mvn:org.apache.sshd/sshd-scp/${sshd.tesb.version}</bundle>
         <bundle start-level="30">mvn:org.apache.sshd/sshd-sftp/${sshd.tesb.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.not-yet-commons-ssl/0.3.11_1</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/${bouncycastle.version}</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk15on/${bouncycastle.version}</bundle>
-        <bundle start-level="30">mvn:org.bouncycastle/bcutil-jdk15on/${bouncycastle.version}</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.tesb.version}</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.tesb.version}</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.tesb.version}</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.shell/org.apache.karaf.shell.ssh/${org.apache.karaf.shell.ssh.tesb.version}</bundle>
     </feature>
 
@@ -1480,7 +1480,7 @@ org.apache.felix.eventadmin.AddSubject=${env:ORG_APACHE_FELIX_EVENTADMIN_IMPL_EV
 
     <feature name="spring-security-crypto-encryption" description="Advanced encryption support for Karaf security" version="${upstream.version}">
         <feature>jaas</feature>
-        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk15on/${bouncycastle.version}</bundle>
+        <bundle start-level="30">mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.tesb.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-security-crypto/${spring.security53.version}</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.jaas/org.apache.karaf.jaas.spring-security-crypto/${upstream.version}</bundle>
     </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
 
     <properties>
         <upstream.version>4.2.11</upstream.version>
-        <standard.features.tesb.version>4.2.11.20230905</standard.features.tesb.version>
+        <standard.features.tesb.version>4.2.11.20230719</standard.features.tesb.version>
         <framework.features.tesb.version>4.2.11.20221129</framework.features.tesb.version>
         <enterprise.features.tesb.version>4.2.11.20221230</enterprise.features.tesb.version>
         <enterprise-legacy.features.tesb.version>4.2.11.20220318</enterprise-legacy.features.tesb.version>
@@ -164,6 +164,7 @@
         <jackson-databind.tesb.version>2.14.1</jackson-databind.tesb.version>
         <sshd.tesb.version>2.9.2</sshd.tesb.version>
         <jaas.modules.tesb.version>4.2.11.20221230</jaas.modules.tesb.version>
+		<bouncycastle.tesb.version>1.74</bouncycastle.tesb.version>
 
         <activemq.version>5.15.11</activemq.version>
         <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
@@ -459,6 +460,7 @@
                             <jackson-databind.tesb.version>${jackson-databind.tesb.version>}</jackson-databind.tesb.version>
                             <sshd.tesb.version>${sshd.tesb.version>}</sshd.tesb.version>
                             <jaas.modules.tesb.version>${jaas.modules.tesb.version>}</jaas.modules.tesb.version>
+                            <bouncycastle.tesb.version>${bouncycastle.tesb.version}</bouncycastle.tesb.version>
                         </properties>
                     </configuration>
                     <executions>


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-6290](https://jira.talendforge.org/browse/TPRUN-6290)

🔍 **What is the problem this PR is trying to solve?**
BouncyCastle<1.74 doesn't check the X.500 name of any certificate, subject, or issuer being passed in for LDAP wild cards which can lead to LDAP injections

🚀 **What is the chosen solution to this problem?**
Bump-up bouncycastle version

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR