### PR TITLE
TPRUN-7563 Update of Spring 5.3 to latest available version.

### DIFF
--- a/assemblies/features/spring/src/main/feature/feature.xml
+++ b/assemblies/features/spring/src/main/feature/feature.xml
@@ -58,7 +58,7 @@
 
     <feature name="spring-messaging" description="Spring 5.3.x Messaging support" version="${spring53.tesb.version}">
         <feature version="[${spring53.tesb.version},5.4)">spring</feature>
-        <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-messaging/${spring53.tesb.version}</bundle>
+        <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-messaging/${springmessaging53.tesb.version}</bundle>
     </feature>
 
     <feature name="spring-test" description="Spring 5.3.x Test support" version="${spring53.tesb.version}">

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <spec.mail.tesb.version>1.6.7</spec.mail.tesb.version>
         <bouncycastle.tesb.version>1.76</bouncycastle.tesb.version>
         <spring53.tesb.version>5.3.31_1</spring53.tesb.version>
+        <springmessaging53.tesb.version>5.3.30_1</springmessaging53.tesb.version>
         <spring.security57.tesb.version>5.7.5_1</spring.security57.tesb.version>
         <spring.security58.tesb.version>5.8.6_1</spring.security58.tesb.version>
         <jackson.tesb.version>2.14.3</jackson.tesb.version>
@@ -489,6 +490,7 @@
                             <spec.mail.tesb.version>${spec.mail.tesb.version}</spec.mail.tesb.version>
                             <bouncycastle.tesb.version>${bouncycastle.tesb.version}</bouncycastle.tesb.version>
                             <spring53.tesb.version>${spring53.tesb.version}</spring53.tesb.version>
+                            <springmessaging53.tesb.version>${springmessaging53.tesb.version}</springmessaging53.tesb.version>
                             <spring.security57.tesb.version>${spring.security57.tesb.version}</spring.security57.tesb.version>
                             <spring.security58.tesb.version>${spring.security58.tesb.version}</spring.security58.tesb.version>
                             <jackson.tesb.version>${jackson.tesb.version}</jackson.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <specs.features.tesb.version>4.4.3.20231031</specs.features.tesb.version>
         <standard.features.tesb.version>4.4.3.20231031</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.3.20231031</enterprise.features.tesb.version>
-        <spring.features.tesb.version>4.4.3.20231031</spring.features.tesb.version>
+        <spring.features.tesb.version>4.4.3.20240206</spring.features.tesb.version>
         <spring-legacy.features.tesb.version>4.4.3.20230915</spring-legacy.features.tesb.version>
         <karaf.main.tesb.version>4.4.3.20230726</karaf.main.tesb.version>
         <karaf.client.tesb.version>4.4.3.20230915</karaf.client.tesb.version>
@@ -168,7 +168,7 @@
         <pax.transx.tesb.version>0.5.4</pax.transx.tesb.version>
         <spec.mail.tesb.version>1.6.7</spec.mail.tesb.version>
         <bouncycastle.tesb.version>1.76</bouncycastle.tesb.version>
-        <spring53.tesb.version>5.3.30_1</spring53.tesb.version>
+        <spring53.tesb.version>5.3.31_1</spring53.tesb.version>
         <spring.security57.tesb.version>5.7.5_1</spring.security57.tesb.version>
         <spring.security58.tesb.version>5.8.6_1</spring.security58.tesb.version>
         <jackson.tesb.version>2.14.3</jackson.tesb.version>


### PR DESCRIPTION
While update to Spring 6.x is not possible, stay with Spring 5.3 at least at the latest version which is currently 5.3.31.