### PR TITLE
DPE-571 Security updates.

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,6 +1,6 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.karaf.wrapper:org.apache.karaf.wrapper.core,org.apache.karaf:org.apache.karaf.main,org.apache.karaf:org.apache.karaf.client,org.apache.karaf.features:specs,org.apache.karaf.features:standard,org.apache.karaf.features:enterprise,org.apache.karaf.features:spring,org.apache.karaf.shell:org.apache.karaf.shell.ssh,org.apache.karaf.webconsole:org.apache.karaf.webconsole.console',
+        MVN_MODULES: 'org.apache.karaf.wrapper:org.apache.karaf.wrapper.core,org.apache.karaf:org.apache.karaf.main,org.apache.karaf:org.apache.karaf.client,org.apache.karaf.features:specs,org.apache.karaf.features:frameword,org.apache.karaf.features:standard,org.apache.karaf.features:enterprise,org.apache.karaf.features:spring,org.apache.karaf.shell:org.apache.karaf.shell.ssh,org.apache.karaf.webconsole:org.apache.karaf.webconsole.console',
         USE_JAVA11: 'true'
 )

--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,6 +1,6 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.karaf.wrapper:org.apache.karaf.wrapper.core,org.apache.karaf:org.apache.karaf.main,org.apache.karaf:org.apache.karaf.client,org.apache.karaf.features:specs,org.apache.karaf.features:frameword,org.apache.karaf.features:standard,org.apache.karaf.features:enterprise,org.apache.karaf.features:spring,org.apache.karaf.shell:org.apache.karaf.shell.ssh,org.apache.karaf.webconsole:org.apache.karaf.webconsole.console',
+        MVN_MODULES: 'org.apache.karaf.wrapper:org.apache.karaf.wrapper.core,org.apache.karaf:org.apache.karaf.main,org.apache.karaf:org.apache.karaf.client,org.apache.karaf.features:specs,org.apache.karaf.features:framework,org.apache.karaf.features:standard,org.apache.karaf.features:enterprise,org.apache.karaf.features:spring,org.apache.karaf.shell:org.apache.karaf.shell.ssh,org.apache.karaf.webconsole:org.apache.karaf.webconsole.console',
         USE_JAVA11: 'true'
 )

--- a/assemblies/features/framework/pom.xml
+++ b/assemblies/features/framework/pom.xml
@@ -33,8 +33,10 @@
     <packaging>pom</packaging>
     <!--<packaging>kar</packaging>-->
     <name>Apache Karaf :: Assemblies :: Features :: Framework</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${framework.features.tesb.version}</revision>
         <appendedResourcesDirectory>${basedir}/../../../etc/appended-resources</appendedResourcesDirectory>
     </properties>
 

--- a/assemblies/features/framework/src/main/feature/feature.xml
+++ b/assemblies/features/framework/src/main/feature/feature.xml
@@ -25,7 +25,7 @@
         <!-- persistent wiring extension -->
         <bundle start-level="1">mvn:org.apache.karaf.features/org.apache.karaf.features.extension/${upstream.version}</bundle>
         <!-- mvn: url handlers -->
-        <bundle start-level="5">mvn:org.ops4j.pax.url/pax-url-aether/${pax.url.version}</bundle>
+        <bundle start-level="5">mvn:org.ops4j.pax.url/pax-url-aether/${pax.url.tesb.version}</bundle>
         <!-- logging -->
         <bundle start-level="8">mvn:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}</bundle>
         <bundle start-level="8">mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax.logging.version}</bundle>
@@ -52,7 +52,7 @@
         <!-- persistent wiring extension -->
         <bundle start-level="1">mvn:org.apache.karaf.features/org.apache.karaf.features.extension/${upstream.version}</bundle>
         <!-- mvn: url handlers -->
-        <bundle start-level="5">mvn:org.ops4j.pax.url/pax-url-aether/${pax.url.version}</bundle>
+        <bundle start-level="5">mvn:org.ops4j.pax.url/pax-url-aether/${pax.url.tesb.version}</bundle>
         <!-- logging -->
         <bundle start-level="8">mvn:org.ops4j.pax.logging/pax-logging-api/${pax.logging.version}</bundle>
         <bundle start-level="8">mvn:org.ops4j.pax.logging/pax-logging-logback/${pax.logging.version}</bundle>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -420,7 +420,7 @@ disableEofExit = false
         <bundle start-level="30">mvn:org.apache.felix/org.osgi.service.obr/${felix.obr.version}</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.bundlerepository/${felix.bundlerepository.version}</bundle>
         <bundle start-level="30">mvn:org.apache.karaf.obr/org.apache.karaf.obr.core/${upstream.version}</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.url/pax-url-obr/${pax.url.version}/jar/uber</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.url/pax-url-obr/${pax.url.tesb.version}/jar/uber</bundle>
     </feature>
 
     <feature name="bundle" description="Provide Bundle support" version="${upstream.version}">
@@ -1492,16 +1492,16 @@ org.apache.felix.eventadmin.AddSubject=true
         <requirement>osgi.implementation;osgi.implementation="osgi.http";version:Version="1.1"</requirement>
     </feature>
 
-    <feature name="pax-url-wrap" description="Wrap URL handler" version="${pax.url.version}">
-        <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-wrap/${pax.url.version}/jar/uber</bundle>
+    <feature name="pax-url-wrap" description="Wrap URL handler" version="${pax.url.tesb.version}">
+        <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-wrap/${pax.url.tesb.version}/jar/uber</bundle>
     </feature>
 
-    <feature name="wrap" description="Transition feature to pax-url-wrap" version="${pax.url.version}">
-        <feature version="${pax.url.version}">pax-url-wrap</feature>
+    <feature name="wrap" description="Transition feature to pax-url-wrap" version="${pax.url.tesb.version}">
+        <feature version="${pax.url.tesb.version}">pax-url-wrap</feature>
     </feature>
 
-    <feature name="pax-url-classpath" description="Classpath URL handler" version="${pax.url.version}">
-        <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-classpath/${pax.url.version}</bundle>
+    <feature name="pax-url-classpath" description="Classpath URL handler" version="${pax.url.tesb.version}">
+        <bundle start-level="10">mvn:org.ops4j.pax.url/pax-url-classpath/${pax.url.tesb.version}</bundle>
     </feature>
 
     <feature name="profile" description="Profiles support" version="${upstream.version}">

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
 
     <properties>
         <upstream.version>4.4.3</upstream.version>
-        <specs.features.tesb.version>4.4.3.20240515</specs.features.tesb.version>
+        <specs.features.tesb.version>4.4.3.20250110</specs.features.tesb.version>
         <framework.features.tesb.version>4.4.3.20250110</framework.features.tesb.version>
         <standard.features.tesb.version>4.4.3.20250110</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.3.20240209</enterprise.features.tesb.version>
@@ -175,7 +175,7 @@
         <springmessaging53.tesb.version>${spring53.tesb.version}</springmessaging53.tesb.version>
         <spring.security57.tesb.version>5.7.14</spring.security57.tesb.version>
         <spring.security58.tesb.version>5.8.16</spring.security58.tesb.version>
-        <jackson.tesb.version>2.16.2</jackson.tesb.version>
+        <jackson.tesb.version>2.17.2</jackson.tesb.version>
         <jackson-databind.tesb.version>${jackson.tesb.version}</jackson-databind.tesb.version>
         <jackson-dataformat-yaml.tesb.version>2.14.3</jackson-dataformat-yaml.tesb.version>
         <cdi-api.tesb.version>2.0.SP1</cdi-api.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -152,9 +152,10 @@
     <properties>
         <upstream.version>4.4.3</upstream.version>
         <specs.features.tesb.version>4.4.3.20240515</specs.features.tesb.version>
-        <standard.features.tesb.version>4.4.3.20240725</standard.features.tesb.version>
+        <framework.features.tesb.version>4.4.3.20250110</framework.features.tesb.version>
+        <standard.features.tesb.version>4.4.3.20250110</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.3.20240209</enterprise.features.tesb.version>
-        <spring.features.tesb.version>4.4.3.20240725</spring.features.tesb.version>
+        <spring.features.tesb.version>4.4.3.20250110</spring.features.tesb.version>
         <spring-legacy.features.tesb.version>4.4.3.20240101</spring-legacy.features.tesb.version>
         <karaf.main.tesb.version>4.4.3.20230726</karaf.main.tesb.version>
         <karaf.client.tesb.version>4.4.3.20230915</karaf.client.tesb.version>
@@ -162,7 +163,8 @@
         <karaf.wrapper.tesb.version>4.4.3.20230925</karaf.wrapper.tesb.version>
         <karaf.webconsole.console.tesb.version>4.4.3.20230726</karaf.webconsole.console.tesb.version>
         <geronimo.jms2-spec.version>1.0-alpha-2</geronimo.jms2-spec.version>
-        <pax.web.tesb.version>8.0.27</pax.web.tesb.version>
+        <pax.web.tesb.version>8.0.29</pax.web.tesb.version>
+        <pax.url.tesb.version>2.6.15</pax.url.tesb.version>
         <pax.jms.tesb.version>1.1.3</pax.jms.tesb.version>
         <pax.jdbc.tesb.version>1.5.6</pax.jdbc.tesb.version>
         <pax.transx.tesb.version>0.5.4</pax.transx.tesb.version>
@@ -183,8 +185,8 @@
         <commons-codec.tesb.version>1.17.0</commons-codec.tesb.version>
         <commons-fileupload.tesb.version>1.5</commons-fileupload.tesb.version>
         <commons-io.tesb.version>2.16.1</commons-io.tesb.version>
-        <commons-lang3.tesb.version>3.14.0</commons-lang3.tesb.version>
-        <jetty.tesb.version>9.4.55.v20240627</jetty.tesb.version>
+        <commons-lang3.tesb.version>3.17.0</commons-lang3.tesb.version>
+        <jetty.tesb.version>9.4.56.v20240826</jetty.tesb.version>
         <xbean.tesb.version>4.24</xbean.tesb.version>
 
         <project.build.outputTimestamp>1</project.build.outputTimestamp>        
@@ -488,6 +490,7 @@
                             <karaf.webconsole.console.tesb.version>${karaf.webconsole.console.tesb.version}</karaf.webconsole.console.tesb.version>
                             <geronimo.jms2-spec.version>${geronimo.jms2-spec.version}</geronimo.jms2-spec.version>
                             <pax.web.tesb.version>${pax.web.tesb.version}</pax.web.tesb.version>
+                            <pax.url.tesb.version>${pax.url.tesb.version}</pax.url.tesb.version>
                             <pax.jms.tesb.version>${pax.jms.tesb.version}</pax.jms.tesb.version>
                             <pax.jdbc.tesb.version>${pax.jdbc.tesb.version}</pax.jdbc.tesb.version>
                             <pax.transx.tesb.version>${pax.transx.tesb.version}</pax.transx.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -173,8 +173,8 @@
         <bouncycastle.tesb.version>1.78.1</bouncycastle.tesb.version>
         <spring53.tesb.version>5.3.39</spring53.tesb.version>
         <springmessaging53.tesb.version>${spring53.tesb.version}</springmessaging53.tesb.version>
-        <spring.security57.tesb.version>5.7.12</spring.security57.tesb.version>
-        <spring.security58.tesb.version>5.8.11</spring.security58.tesb.version>
+        <spring.security57.tesb.version>5.7.14</spring.security57.tesb.version>
+        <spring.security58.tesb.version>5.8.16</spring.security58.tesb.version>
         <jackson.tesb.version>2.16.2</jackson.tesb.version>
         <jackson-databind.tesb.version>${jackson.tesb.version}</jackson-databind.tesb.version>
         <jackson-dataformat-yaml.tesb.version>2.14.3</jackson-dataformat-yaml.tesb.version>


### PR DESCRIPTION
pax-url 2.6.12 -> 2.6.15 - CVE-2024-47554(commons-io)
jetty 9.4.55.v20240627 -> 9.4.56.v20240826 - CVE-2024-8184
spring-security 5.7.12 -> 5.7.14, 5.8.11 -> 5.8.16 - CVE-2024-38821
pax-web 8.0.27 -> 8.0.29 - CVE-2024-8184(jetty)