### PR TITLE
DPE-675: migrate from org.apache.sling/org.apache.sling.commons.johnzon to org.glassfish/javax.json + org.apache.johnzon/johnzon-core

### DIFF
--- a/assemblies/features/framework/src/main/feature/feature.xml
+++ b/assemblies/features/framework/src/main/feature/feature.xml
@@ -22,6 +22,7 @@
               including the correct start-level for the generation of the startup.propertie file -->
 
     <feature version="${upstream.version}" description="Karaf core feature" name="framework" hidden="true">
+        <feature prerequisite="true">spifly</feature>
         <!-- persistent wiring extension -->
         <bundle start-level="1">mvn:org.apache.karaf.features/org.apache.karaf.features.extension/${upstream.version}</bundle>
         <!-- mvn: url handlers -->
@@ -39,7 +40,8 @@
         <bundle start-level="10">mvn:org.apache.felix/org.apache.felix.configadmin/${felix.configadmin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
-        <bundle start-level="11">mvn:org.apache.sling/org.apache.sling.commons.johnzon/${sling.commons.johnzon.version}</bundle>
+        <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
+        <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>
         <!-- file install -->
@@ -50,6 +52,7 @@
     </feature>
 
     <feature version="${upstream.version}" description="Karaf core feature" name="framework-logback" hidden="true">
+        <feature prerequisite="true">spifly</feature>
         <!-- persistent wiring extension -->
         <bundle start-level="1">mvn:org.apache.karaf.features/org.apache.karaf.features.extension/${upstream.version}</bundle>
         <!-- mvn: url handlers -->
@@ -66,7 +69,8 @@
         <bundle start-level="10">mvn:org.apache.felix/org.apache.felix.configadmin/${felix.configadmin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
-        <bundle start-level="11">mvn:org.apache.sling/org.apache.sling.commons.johnzon/${sling.commons.johnzon.version}</bundle>
+        <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
+        <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>
         <!-- file install -->

--- a/assemblies/features/framework/src/main/feature/feature.xml
+++ b/assemblies/features/framework/src/main/feature/feature.xml
@@ -41,6 +41,7 @@
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
         <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
+        <bundle start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/9.99.0</bundle>
         <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>
@@ -70,6 +71,7 @@
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
         <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
+        <bundle start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/9.99.0</bundle>
         <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>

--- a/assemblies/features/specs/src/main/feature/feature.xml
+++ b/assemblies/features/specs/src/main/feature/feature.xml
@@ -19,12 +19,12 @@
 <features name="specs-${upstream.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
     <!-- asm -->
-    <feature name="asm" version="${asm.version}">
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.version}</bundle>
+    <feature name="asm" version="${asm.tesb.version}">
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.tesb.version}</bundle>
     </feature>
 
     <!-- spifly -->

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -37,11 +37,11 @@
 
     <feature name="aries-proxy" description="Aries Proxy" version="${upstream.version}">
         <!-- false to avoid restarts of proxy which cascades badly -->
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.tesb.version}</bundle>
         <bundle start-level="20">mvn:org.apache.aries.proxy/org.apache.aries.proxy/${aries.proxy.version}</bundle>
     </feature>
 

--- a/itests/test/src/test/filtered-resources/etc/feature.xml
+++ b/itests/test/src/test/filtered-resources/etc/feature.xml
@@ -32,11 +32,11 @@
 
     <feature name="aries-proxy" description="Aries Proxy" version="${upstream.version}">
         <!-- false to avoid restarts of proxy which cascades badly -->
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.version}</bundle>
-        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-util/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-tree/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-analysis/${asm.tesb.version}</bundle>
+        <bundle dependency="false" start-level="20">mvn:org.ow2.asm/asm-commons/${asm.tesb.version}</bundle>
         <bundle start-level="20">mvn:org.apache.aries.proxy/org.apache.aries.proxy/${aries.proxy.version}</bundle>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
         <!-- <pax.transx.tesb.version>0.5.4</pax.transx.tesb.version> -->
         <jetty9.tesb.version>9.4.56.v20240826</jetty9.tesb.version>
         <spec.mail.tesb.version>1.6.7</spec.mail.tesb.version>
+        <asm.tesb.version>9.7.1</asm.tesb.version>
         <aspectj.bundle.tesb.version>1.9.21.1_1</aspectj.bundle.tesb.version>
         <bouncycastle.tesb.version>1.78.1</bouncycastle.tesb.version>
         <spring53.tesb.version>5.3.39</spring53.tesb.version>
@@ -524,6 +525,7 @@
                             <!-- <pax.transx.tesb.version>${pax.transx.tesb.version}</pax.transx.tesb.version> -->
                             <jetty9.tesb.version>${jetty9.tesb.version}</jetty9.tesb.version>
                             <spec.mail.tesb.version>${spec.mail.tesb.version}</spec.mail.tesb.version>
+                            <asm.tesb.version>9.7.1</asm.tesb.version>
                             <aspectj.bundle.tesb.version>${aspectj.bundle.tesb.version}</aspectj.bundle.tesb.version>
                             <bouncycastle.tesb.version>${bouncycastle.tesb.version}</bouncycastle.tesb.version>
                             <spring53.tesb.version>${spring53.tesb.version}</spring53.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,8 @@
         <jackson.tesb.version>2.18.2</jackson.tesb.version>
         <jackson-databind.tesb.version>${jackson.tesb.version}</jackson-databind.tesb.version>
         <jackson-dataformat-yaml.tesb.version>${jackson.tesb.version}</jackson-dataformat-yaml.tesb.version>
+        <javax.json.tesb.version>1.1.4</javax.json.tesb.version>
+        <johnzon.core.tesb.version>1.2.21</johnzon.core.tesb.version>
         <snakeyaml.tesb.version>2.3</snakeyaml.tesb.version>
         <cdi-api.tesb.version>2.0.SP1</cdi-api.tesb.version>
         <!-- <sshd.tesb.version>2.12.1</sshd.tesb.version> -->
@@ -532,6 +534,8 @@
                             <jackson.tesb.version>${jackson.tesb.version}</jackson.tesb.version>
                             <jackson-databind.tesb.version>${jackson-databind.tesb.version}</jackson-databind.tesb.version>
                             <jackson-dataformat-yaml.tesb.version>${jackson-dataformat-yaml.tesb.version}</jackson-dataformat-yaml.tesb.version>
+                            <javax.json.tesb.version>${javax.json.tesb.version}</javax.json.tesb.version>
+                            <johnzon.core.tesb.version>${johnzon.core.tesb.version}</johnzon.core.tesb.version>
                             <snakeyaml.tesb.version>${snakeyaml.tesb.version}</snakeyaml.tesb.version>
                             <cdi-api.tesb.version>${cdi-api.tesb.version}</cdi-api.tesb.version>
                             <!-- <sshd.tesb.version>${sshd.tesb.version}</sshd.tesb.version> -->

--- a/pom.xml
+++ b/pom.xml
@@ -525,7 +525,7 @@
                             <!-- <pax.transx.tesb.version>${pax.transx.tesb.version}</pax.transx.tesb.version> -->
                             <jetty9.tesb.version>${jetty9.tesb.version}</jetty9.tesb.version>
                             <spec.mail.tesb.version>${spec.mail.tesb.version}</spec.mail.tesb.version>
-                            <asm.tesb.version>9.7.1</asm.tesb.version>
+                            <asm.tesb.version>${asm.tesb.version}</asm.tesb.version>
                             <aspectj.bundle.tesb.version>${aspectj.bundle.tesb.version}</aspectj.bundle.tesb.version>
                             <bouncycastle.tesb.version>${bouncycastle.tesb.version}</bouncycastle.tesb.version>
                             <spring53.tesb.version>${spring53.tesb.version}</spring53.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-675](https://qlik-dev.atlassian.net/browse/DPE-675)

🔍 **What is the problem this PR is trying to solve?**
Karaf `4.4.6` is not compatible with Decanter `2.9.0`/`2.10.0` due to conflicts in the Export-Package of the following bundles:
`org.apache.sling/org.apache.sling.commons.johnzon/1.2.16`
```
Export-Package =
        javax.json;uses:=javax.json.stream;version=1.1,
        javax.json.spi;uses:="javax.json,javax.json.stream";version=1.1,
        javax.json.stream;uses:=javax.json;version=1.1,
        org.apache.johnzon.core;uses:="javax.json,javax.json.spi,javax.json.stream,org.apache.johnzon.core.spi";version=1.2.21,
        org.apache.johnzon.core.io;version=1.2.21,
        org.apache.johnzon.core.spi;uses:="javax.json,javax.json.spi";version=1.2.21,
        org.apache.johnzon.core.util;version=1.2.21
```
`mvn:org.glassfish/javax.json/1.1.4`
```
Export-Package =
        javax.json;uses:=javax.json.stream;version=1.1.4,
        javax.json.spi;uses:="javax.json,javax.json.stream";version=1.1.4,
        javax.json.stream;uses:=javax.json;version=1.1.4,
        org.glassfish.json.api;version=1.1.4
```
When the Decanter features are installed, unnecessary bundles are refreshed, which causes service references to be lost, for instance, the `org.apache.karaf.decanter.api.marshaller.Marshaller` service reference in `org.apache.karaf.decanter.appender.log.LogAppender`.

🚀 **What is the chosen solution to this problem?**
In Karaf framework features migrate from `org.apache.sling/org.apache.sling.commons.johnzon` to `org.glassfish/javax.json` (and a fragmet bundle for SPI-FLY)+ `org.apache.johnzon/johnzon-core`.
Match `asm.version` with the one used in the `tesb-rt-se` build.

**Why the glassfish bundle?**
- :x:`org.apache.geronimo.specs/geronimo-json_1.1_spec/1.5`  - Its `Require-Capability` declares `javax.json.spi.JsonProvider` which is provided by `org.apache.johnzon/johnzon-core/1.2.21` and, as a consequence, creates a circular dependency.
-  - `org.apache.geronimo.specs/geronimo-json_1.1_spec/1.5`
```
Export-Package: javax.json;version="1.1";uses:="javax.json.stream",jav
...
Provide-Capability: osgi.contract;osgi.contract=JavaJSONP;uses:="javax
 .json,javax.json.stream,javax.json.spi";version:List<Version>="1.1,1.
 0"
Require-Capability: osgi.serviceloader;filter:="(osgi.serviceloader=ja
 vax.json.spi.JsonProvider)";cardinality:=multiple,osgi.extender;filte
 r:="(osgi.extender=osgi.serviceloader.processor)",osgi.ee;filter:="(&
 (osgi.ee=JavaSE)(version=1.8))"
``` 
-  - `org.apache.johnzon/johnzon-core/1.2.21`
```
Import-Package: javax.json,javax.json.spi,javax.json.stream,org.apache
...
Provide-Capability: osgi.serviceloader;osgi.serviceloader="javax.json.
 spi.JsonProvider"
``` 
- `javax.json/javax.json-api/1.1.4` - I didn't see any advantage/disadvantage over the glassfish bundle, but for our use case, it is more convenient to go with the glassfish bundle.


🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-675]: https://qlik-dev.atlassian.net/browse/DPE-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ