### PR TITLE
fix(DPE-704) : upgrade jolokia to v2 to be compatible with jakarta

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1544,7 +1544,7 @@ profilesDirectory = ${karaf.home}/profiles
         <bundle>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
     </feature>
 
-    <feature name="jolokia" description="Jolokia monitoring support" version="${jolokia.version}">
+    <feature name="jolokia" description="Jolokia monitoring support" version="${jolokia.tesb.version}">
         <config name="org.jolokia.osgi">
 ################################################################################
 #
@@ -1569,7 +1569,7 @@ org.jolokia.user=karaf
 org.jolokia.realm=karaf
 org.jolokia.authMode=jaas
         </config>
-        <bundle>mvn:org.jolokia/jolokia-osgi/${jolokia.version}</bundle>
+        <bundle>mvn:org.jolokia/jolokia-agent-osgi/${jolokia.tesb.version}</bundle>
         <requirement>osgi.implementation;osgi.implementation="osgi.http";version:Version="1.1"</requirement>
     </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,7 @@
         <servlet.spec.tesb.groupId>jakarta.servlet</servlet.spec.tesb.groupId>
         <servlet.spec.tesb.artifactId>jakarta.servlet-api</servlet.spec.tesb.artifactId>
         <servlet.spec.tesb.version>6.1.0</servlet.spec.tesb.version>
+        <jolokia.tesb.version>2.2.1</jolokia.tesb.version>
 
         <project.build.outputTimestamp>1712650974</project.build.outputTimestamp>        
 


### PR DESCRIPTION
🏁 **Context (Jira, design, ...)**
[DPE-704](https://qlik-dev.atlassian.net/browse/DPE-704)

🔍 **What is the problem this PR is trying to solve?**
Jolokia feature cannot be installed

🚀 **What is the chosen solution to this problem?**
Update jolokia to version 2.2.1 which supports jakarta 

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR