### PR TITLE
fix(DPE-1888): correct `org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish` version

### DIFF
--- a/assemblies/features/framework/src/main/feature/feature.xml
+++ b/assemblies/features/framework/src/main/feature/feature.xml
@@ -48,7 +48,7 @@
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
         <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
-        <bundle dependency="true" start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/11.0.0</bundle>
+        <bundle dependency="true" start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/${pax.web.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>
@@ -84,7 +84,7 @@
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configadmin.plugin.interpolation/${felix.configadmin.interpolation.plugin.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.cm.json/${felix.cm.json.version}</bundle>
         <bundle start-level="11">mvn:org.glassfish/javax.json/${javax.json.tesb.version}</bundle>
-        <bundle dependency="true" start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/11.0.0</bundle>
+        <bundle dependency="true" start-level="11" start="false">mvn:org.ops4j.pax.web/pax-web-fragment-jsonp-javax-glassfish/${pax.web.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.johnzon/johnzon-core/${johnzon.core.tesb.version}</bundle>
         <bundle start-level="11">mvn:org.apache.felix/org.apache.felix.configurator/${felix.configurator.version}</bundle>
         <bundle start-level="11">mvn:org.apache.karaf.config/org.apache.karaf.config.core/${upstream.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <upstream.version>4.4.6</upstream.version>
         <base.features.tesb.version>4.4.6.20250420</base.features.tesb.version>
         <specs.features.tesb.version>4.4.6.20250901</specs.features.tesb.version>
-        <framework.features.tesb.version>4.4.6.20250901</framework.features.tesb.version>
+        <framework.features.tesb.version>4.4.6.20251010</framework.features.tesb.version>
         <standard.features.tesb.version>4.4.6.20250901</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.6.20250901</enterprise.features.tesb.version>
         <spring.features.tesb.version>4.4.6.20251001</spring.features.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-1888](https://qlik-dev.atlassian.net/browse/DPE-1888)

🔍 **What is the problem this PR is trying to solve?**

🚀 **What is the chosen solution to this problem?**

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-1888]: https://qlik-dev.atlassian.net/browse/DPE-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ