### PR TITLE
fix(DPE-1850) : restore all webconsole plugins

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -998,6 +998,7 @@ role=admin
         <bundle start-level="30">mvn:org.apache.karaf.webconsole/org.apache.karaf.webconsole.console/${karaf.webconsole.tesb.version}</bundle>
         <bundle start-level="30">mvn:org.owasp.encoder/encoder/1.3.1</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.wrappers/1.1.8</bundle>
+        <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.inventory/${felix.inventory.version}</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.webconsole.plugins.memoryusage/${felix.memoryusage.webconsole.plugin.tesb.version}</bundle>
         <conditional>
             <condition>instance</condition>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1000,6 +1000,7 @@ role=admin
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.wrappers/1.1.8</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.inventory/${felix.inventory.version}</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.webconsole.plugins.memoryusage/${felix.memoryusage.webconsole.plugin.tesb.version}</bundle>
+        <bundle start-level="30">wrap:mvn:org.apache.felix/org.apache.felix.webconsole.plugins.memoryusage/${felix.memoryusage.webconsole.plugin.tesb.version}$overwrite=merge&amp;Import-Package=javax.management,org.osgi.framework;version="[1.8,2)",org.osgi.service.cm;resolution:=optional;version="[1.2,2)",org.osgi.service.metatype;resolution:=optional;version="[1.1,2)",jakarta.servlet;resolution:=optional;version="[5,7)",jakarta.servlet.http;resolution:=optional;version="[5,7)",org.apache.felix.webconsole.servlet;resolution:=mandatory;version="${felix.webconsole.range.tesb.version}",org.apache.felix.inventory;resolution:=optional;version="[1.0,2)",org.apache.felix.shell;resolution:=optional;version="[1.0,1.1)",*</bundle>
         <conditional>
             <condition>instance</condition>
             <bundle start-level="30">mvn:org.apache.karaf.webconsole/org.apache.karaf.webconsole.instance/${karaf.webconsole.tesb.version}</bundle>

--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1496,7 +1496,7 @@ org.apache.felix.eventadmin.AddSubject=true
         <conditional>
             <condition>webconsole</condition>
             <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.inventory/${felix.inventory.version}</bundle>
-            <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.webconsole.plugins.ds/${felix.scr.webconsole.plugin.tesb.version}</bundle>
+            <bundle start-level="30">wrap:mvn:org.apache.felix/org.apache.felix.webconsole.plugins.ds/${felix.scr.webconsole.plugin.tesb.version}$overwrite=merge&amp;Import-Package=org.osgi.service.cm;resolution:=optional;version="[1.6,2)",org.osgi.service.metatype;resolution:=optional;version="[1.2,2)",jakarta.servlet*;version="[5,7)",org.apache.felix.inventory;version="[1.0,2)",org.apache.felix.webconsole.*;version="${felix.webconsole.range.tesb.version}",org.osgi.framework;version="[1.8,2)",org.osgi.framework.dto;version="[1.8,2)",org.osgi.service.component.runtime;version="[1.4,2)",org.osgi.service.component.runtime.dto;version="[1.4,2)",org.osgi.util.promise;version="[1.0,2)",org.osgi.util.tracker;version="[1.5,2)",*</bundle>
         </conditional>
         <conditional>
             <condition>bundle</condition>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <karaf.wrapper.tesb.version>4.4.6.20250320</karaf.wrapper.tesb.version>
         <karaf.http.core.tesb.version>4.4.6.20250901</karaf.http.core.tesb.version>
         <karaf.web.core.tesb.version>4.4.6.20250901</karaf.web.core.tesb.version>
-        <karaf.webconsole.tesb.version>4.4.6.20250901</karaf.webconsole.tesb.version>
+        <karaf.webconsole.tesb.version>4.4.6.20251001</karaf.webconsole.tesb.version>
         <felix.webconsole.tesb.version>5.0.12</felix.webconsole.tesb.version>
         <felix.webconsole.api.tesb.version>5.0.10</felix.webconsole.api.tesb.version>
         <felix.eventadmin.webconsole.plugin.tesb.version>1.2.0</felix.eventadmin.webconsole.plugin.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <base.features.tesb.version>4.4.6.20250420</base.features.tesb.version>
         <specs.features.tesb.version>4.4.6.20250901</specs.features.tesb.version>
         <framework.features.tesb.version>4.4.6.20250901</framework.features.tesb.version>
-        <standard.features.tesb.version>4.4.6.20250901</standard.features.tesb.version>
+        <standard.features.tesb.version>4.4.6.20251013</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.6.20250901</enterprise.features.tesb.version>
         <spring.features.tesb.version>4.4.6.20250901</spring.features.tesb.version>
         <spring-legacy.features.tesb.version>4.4.6.20240820</spring-legacy.features.tesb.version>
@@ -166,9 +166,10 @@
         <karaf.wrapper.tesb.version>4.4.6.20250320</karaf.wrapper.tesb.version>
         <karaf.http.core.tesb.version>4.4.6.20250901</karaf.http.core.tesb.version>
         <karaf.web.core.tesb.version>4.4.6.20250901</karaf.web.core.tesb.version>
-        <karaf.webconsole.tesb.version>4.4.6.20251001</karaf.webconsole.tesb.version>
+        <karaf.webconsole.tesb.version>4.4.6.20251013</karaf.webconsole.tesb.version>
         <felix.webconsole.tesb.version>5.0.12</felix.webconsole.tesb.version>
         <felix.webconsole.api.tesb.version>5.0.10</felix.webconsole.api.tesb.version>
+        <felix.webconsole.range.tesb.version>[5,6)</felix.webconsole.range.tesb.version>
         <felix.eventadmin.webconsole.plugin.tesb.version>1.2.0</felix.eventadmin.webconsole.plugin.tesb.version>
         <felix.memoryusage.webconsole.plugin.tesb.version>1.1.0</felix.memoryusage.webconsole.plugin.tesb.version>
         <felix.scr.webconsole.plugin.tesb.version>2.3.0</felix.scr.webconsole.plugin.tesb.version>
@@ -272,7 +273,7 @@
         <easymock.version>5.2.0</easymock.version>
         <equinox.groupId>org.eclipse.platform</equinox.groupId>
         <equinox.artifactId>org.eclipse.osgi</equinox.artifactId>
-        <equinox.version>3.18.0</equinox.version>
+        <equinox.version>3.18.400</equinox.version>
         <equinox.region.version>1.5.300</equinox.region.version>
         <equinox.coordinator.version>1.5.200</equinox.coordinator.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <felix.gogo.jline.version>1.1.8</felix.gogo.jline.version>
         <felix.httplite.version>0.1.6</felix.httplite.version>
         <felix.http.version>4.2.2</felix.http.version>
-        <felix.inventory.version>1.1.0</felix.inventory.version>
+        <felix.inventory.version>2.0.0</felix.inventory.version>
         <felix.maven-bundle-plugin.version>5.1.9</felix.maven-bundle-plugin.version>
         <felix.utils.version>1.11.8</felix.utils.version>
         <felix.webconsole.version>4.8.12</felix.webconsole.version>

--- a/webconsole/console/pom.xml
+++ b/webconsole/console/pom.xml
@@ -155,7 +155,8 @@
                         <Export-Package>
                             org.apache.felix.webconsole;version="${felix.webconsole.api.tesb.version}";provide:=true,
                             org.apache.felix.webconsole.bundleinfo;version=1.0.0;provide:=true,
-                            org.apache.felix.webconsole.i18n;version=1.0.0;provide:=true
+                            org.apache.felix.webconsole.i18n;version=1.0.0;provide:=true,
+                            org.apache.felix.webconsole.servlet;version=1.0.0;provide:=true
                         </Export-Package>
                         <Private-Package>
                             !org.apache.felix.webconsole,

--- a/webconsole/console/pom.xml
+++ b/webconsole/console/pom.xml
@@ -154,9 +154,9 @@
                         </Bundle-Activator>
                         <Export-Package>
                             org.apache.felix.webconsole;version="${felix.webconsole.api.tesb.version}";provide:=true,
-                            org.apache.felix.webconsole.bundleinfo;version=1.0.0;provide:=true,
-                            org.apache.felix.webconsole.i18n;version=1.0.0;provide:=true,
-                            org.apache.felix.webconsole.servlet;version=1.0.0;provide:=true
+                            org.apache.felix.webconsole.bundleinfo;version="${felix.webconsole.api.tesb.version}";provide:=true,
+                            org.apache.felix.webconsole.i18n;version="${felix.webconsole.api.tesb.version}";provide:=true,
+                            org.apache.felix.webconsole.servlet;version="${felix.webconsole.api.tesb.version}";provide:=true
                         </Export-Package>
                         <Private-Package>
                             !org.apache.felix.webconsole,
@@ -164,7 +164,7 @@
                             org.apache.karaf.util.jaas
                         </Private-Package>
                         <Import-Package>
-                            jakarta.servlet.*;version="[5,7)",
+                            jakarta.servlet.*;version="[6,7)",
                             !javax.portlet,
                             !javax.servlet,
                             !javax.servlet.http,
@@ -180,6 +180,7 @@
                             !org.osgi.service.permissionadmin,
                             !org.osgi.service.prefs,
                             !org.osgi.service.wireadmin,
+                            !org.osgi.util,
                             org.apache.felix.inventory;resolution:="optional",
                             *
                         </Import-Package>
@@ -203,8 +204,9 @@
                             org.apache.felix.utils.json;inline=org/apache/felix/utils/json/**,
                             org.apache.felix.framework;inline=org/apache/felix/framework/util/VersionRange**,
 
-                            <!-- ServiceTracker -->
+                            <!-- ServiceTracker
                             osgi.core;inline=org/osgi/util/tracker/*,
+                             -->
 
                             <!-- File Upload -->
                             commons-fileupload,

--- a/webconsole/features/pom.xml
+++ b/webconsole/features/pom.xml
@@ -117,7 +117,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.felix.webconsole*;version="[8,9)",
+                            org.apache.felix.webconsole*;version="${felix.webconsole.range.tesb.version}",
                             jakarta.servlet*;version="[6,7)",
                             *
                         </Import-Package>

--- a/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/Activator.java
+++ b/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/Activator.java
@@ -42,6 +42,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "features");
+        props.put("felix.webconsole.title", "features");
         register(Servlet.class, featuresPlugin, props);
     }
 

--- a/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/Activator.java
+++ b/webconsole/features/src/main/java/org/apache/karaf/webconsole/features/Activator.java
@@ -42,7 +42,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "features");
-        props.put("felix.webconsole.title", "features");
+        props.put("felix.webconsole.title", "Features");
         register(Servlet.class, featuresPlugin, props);
     }
 

--- a/webconsole/gogo/pom.xml
+++ b/webconsole/gogo/pom.xml
@@ -136,12 +136,12 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.felix.webconsole*;version="[8,9)",
+                            org.apache.felix.webconsole*;version="${felix.webconsole.range.tesb.version}",
                             jakarta.servlet*;version="[6,7)",
                             *
                         </Import-Package>
                         <Private-Package>
-                            org.apache.felix.utils.json
+                            org.apache.karaf.util.tracker;-split-package:=first,
                         </Private-Package>
                     </instructions>
                 </configuration>

--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Activator.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Activator.java
@@ -41,6 +41,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "gogo");
+        props.put("felix.webconsole.title", "gogo");
         register(Servlet.class, gogoPlugin, props);
     }
 

--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Activator.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/Activator.java
@@ -41,7 +41,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "gogo");
-        props.put("felix.webconsole.title", "gogo");
+        props.put("felix.webconsole.title", "Gogo");
         register(Servlet.class, gogoPlugin, props);
     }
 

--- a/webconsole/gogo/src/main/resources/res/ui/gogo.js
+++ b/webconsole/gogo/src/main/resources/res/ui/gogo.js
@@ -57,11 +57,7 @@ gogo.Terminal_ctor = function(div, width, height) {
            while (keybuf.length > 0) {
                send += keybuf.pop();
            }
-           var query = query1 + send;
-           if (force) {
-               query = query + "&f=1";
-               force = 0;
-           }
+           var query = query1 + send + "&f=1";
            r.open("POST", "gogo", true);
            r.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
            r.onreadystatechange = function () {

--- a/webconsole/http/pom.xml
+++ b/webconsole/http/pom.xml
@@ -134,8 +134,9 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.felix.webconsole*;version="[8,9)",
+                            org.apache.felix.webconsole*;version="${felix.webconsole.range.tesb.version}",
                             jakarta.servlet*;version="[6,7)",
+                            !org.apache.karaf.util,
                             *
                         </Import-Package>
                         <Private-Package>

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/Activator.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/Activator.java
@@ -53,6 +53,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "http");
+        props.put("felix.webconsole.title", "http");
         register(Servlet.class, httpPlugin, props);
     }
 

--- a/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/Activator.java
+++ b/webconsole/http/src/main/java/org/apache/karaf/webconsole/http/Activator.java
@@ -53,7 +53,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "http");
-        props.put("felix.webconsole.title", "http");
+        props.put("felix.webconsole.title", "Http");
         register(Servlet.class, httpPlugin, props);
     }
 

--- a/webconsole/instance/pom.xml
+++ b/webconsole/instance/pom.xml
@@ -126,8 +126,9 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
-                            org.apache.felix.webconsole*;version="[8,9)",
+                            org.apache.felix.webconsole*;version="${felix.webconsole.range.tesb.version}",
                             jakarta.servlet*;version="[6,7)",
+                            !org.apache.karaf.util*,
                             *
                         </Import-Package>
                         <Private-Package>

--- a/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/Activator.java
+++ b/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/Activator.java
@@ -41,6 +41,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "instance");
+        props.put("felix.webconsole.title", "instance");
         register(Servlet.class, instancePlugin, props);
     }
 

--- a/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/Activator.java
+++ b/webconsole/instance/src/main/java/org/apache/karaf/webconsole/instance/Activator.java
@@ -41,7 +41,7 @@ public class Activator extends BaseActivator {
 
         Dictionary<String, String> props = new Hashtable<>();
         props.put("felix.webconsole.label", "instance");
-        props.put("felix.webconsole.title", "instance");
+        props.put("felix.webconsole.title", "Instance");
         register(Servlet.class, instancePlugin, props);
     }
 


### PR DESCRIPTION
🏁 **Context**
- [DPE-1850](https://qlik-dev.atlassian.net/browse/DPE-1850)

🔍 **What is the problem this PR is trying to solve?**
Some plugins of the webconsole don't work

🚀 **What is the chosen solution to this problem?**
- upgrade inventory bundle to 2.0.0 so that it's a jakarta servlet, not javax
- add title to gogo, instance, feature so that the filter work
- fix manifests to make the bundle work (otherwise conditional silently fails)
- fix javascript to display the console
- fix features.xml , use wrap to set the correct versions in Import-Package

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-1850]: https://qlik-dev.atlassian.net/browse/DPE-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ