### PR TITLE
fix(DPE-2108): close thread in gogo plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <karaf.wrapper.tesb.version>4.4.6.20250320</karaf.wrapper.tesb.version>
         <karaf.http.core.tesb.version>4.4.6.20250901</karaf.http.core.tesb.version>
         <karaf.web.core.tesb.version>4.4.6.20250901</karaf.web.core.tesb.version>
-        <karaf.webconsole.tesb.version>4.4.6.20251013</karaf.webconsole.tesb.version>
+        <karaf.webconsole.tesb.version>4.4.6.20251204</karaf.webconsole.tesb.version>
         <felix.webconsole.tesb.version>5.0.12</felix.webconsole.tesb.version>
         <felix.webconsole.api.tesb.version>5.0.10</felix.webconsole.api.tesb.version>
         <felix.webconsole.range.tesb.version>[5,6)</felix.webconsole.range.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <base.features.tesb.version>4.4.6.20250420</base.features.tesb.version>
         <specs.features.tesb.version>4.4.6.20250901</specs.features.tesb.version>
         <framework.features.tesb.version>4.4.6.20251010</framework.features.tesb.version>
-        <standard.features.tesb.version>4.4.6.20251013</standard.features.tesb.version>
+        <standard.features.tesb.version>4.4.6.20251204</standard.features.tesb.version>
         <enterprise.features.tesb.version>4.4.6.20250901</enterprise.features.tesb.version>
         <spring.features.tesb.version>4.4.6.20251001</spring.features.tesb.version>
         <spring-legacy.features.tesb.version>4.4.6.20240820</spring-legacy.features.tesb.version>

--- a/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
+++ b/webconsole/gogo/src/main/java/org/apache/karaf/webconsole/gogo/GogoPlugin.java
@@ -157,10 +157,8 @@ public class GogoPlugin extends AbstractServlet {
             if (supportsGzip) {
                 response.setHeader("Content-Encoding", "gzip");
                 response.setHeader("Content-Type", "text/html");
-                try {
-                    GZIPOutputStream gzos = new GZIPOutputStream(response.getOutputStream());
+                try ( GZIPOutputStream gzos = new GZIPOutputStream(response.getOutputStream())) {
                     gzos.write(dump.getBytes());
-                    gzos.close();
                 } catch (IOException ie) {
                     // handle the error here
                     ie.printStackTrace();
@@ -177,7 +175,7 @@ public class GogoPlugin extends AbstractServlet {
         private Terminal terminal;
         private PipedOutputStream in;
         private PipedInputStream out;
-        private boolean closed;
+        private volatile boolean closed;
 
         public SessionTerminal() throws IOException {
             try {
@@ -196,7 +194,7 @@ public class GogoPlugin extends AbstractServlet {
                         pipedOut,
                         new WebTerminal(TERM_WIDTH, TERM_HEIGHT, input, pipedOut),
                         null,
-                        null);
+                        () -> closed = true);
                 new Thread(session, "Karaf web console user " + getCurrentUserName()).start();
             } catch (IOException e) {
                 e.printStackTrace();
@@ -242,9 +240,10 @@ public class GogoPlugin extends AbstractServlet {
             }
         }
 
+        @Override
         public void run() {
             try {
-                for (; ; ) {
+                while (!closed) {
                     byte[] buf = new byte[8192];
                     int l = out.read(buf);
                     InputStreamReader r = new InputStreamReader(new ByteArrayInputStream(buf, 0, l));
@@ -269,6 +268,13 @@ public class GogoPlugin extends AbstractServlet {
             } catch (IOException e) {
                 closed = true;
                 e.printStackTrace();
+            } finally {
+                try {
+                    in.close();
+                } catch (IOException ignored) {}
+                try {
+                    out.close();
+                } catch (IOException ignored) {}
             }
         }
 


### PR DESCRIPTION
🏁 **Context**
- [DPE-2108](https://qlik-dev.atlassian.net/browse/DPE-2108)

🔍 **What is the problem this PR is trying to solve?**
Gogo plugin uses CPU, and leave threads even if it's closed
 
🚀 **What is the chosen solution to this problem?**
Fix code to stop correctly the thread SessionTerminal on logout

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-2108]: https://qlik-dev.atlassian.net/browse/DPE-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ